### PR TITLE
Fix name of $shippingDetails in jsonSerialize

### DIFF
--- a/src/Request/CreatePayment.php
+++ b/src/Request/CreatePayment.php
@@ -405,7 +405,7 @@ class CreatePayment extends AbstractRequest
         }
 
         // If there are shipping details, then merge it in:
-        if (! empty($shippingAddress)) {
+        if (! empty($shippingDetails)) {
             $result['shippingDetails'] = $shippingDetails;
         }
 


### PR DESCRIPTION
`$shippingAddress` was being checked instead of `$shippingDetails`,  which has just been prepared and is being merged in that if block.

This was causing the request to never have the optional parameter of shipping address. This commit fixes that.